### PR TITLE
Debug: GitHub Actions 워크플로우에서 scp 대신 rsync를 통해 .git 제외

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Add EC2 to known_hosts
         run: ssh-keyscan -H ${{ secrets.EC2_IP }} >> ~/.ssh/known_hosts
 
-      - name: Copy project to EC2
-        run: scp -r ./ ${{ secrets.EC2_HOST }}:~/app
+      - name: Sync project to EC2
+        run: rsync -avz --exclude='.git' ./ ${{ secrets.EC2_HOST }}:~/app
 
       - name: Deploy on EC2
         run: |


### PR DESCRIPTION
GitHub Actions 워크플로우에서 scp 대신 rsync를 통해 .git 제외