### PR TITLE
FIX: application.yml 수정 백엔드 배포 환경에 맞춰 OAuth2 리디렉트 방식 및 CORS 수정

### DIFF
--- a/src/main/java/org/tutortalk/be/global/config/SecurityConfig.java
+++ b/src/main/java/org/tutortalk/be/global/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
-                        .allowedOrigins("http://localhost:3000")
+                        .allowedOrigins("http://localhost:3000","http://127.0.0.1:5500", "http://localhost:5500")
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
                         .allowedHeaders("*")
                         .allowCredentials(true); // 인증정보 (쿠키, 인증 헤더) 허용

--- a/src/main/java/org/tutortalk/be/global/oauth/GoogleOAuth2SuccessHandler.java
+++ b/src/main/java/org/tutortalk/be/global/oauth/GoogleOAuth2SuccessHandler.java
@@ -49,26 +49,33 @@ public class GoogleOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
         });
 
         Boolean isProfileComplete = user.isProfileComplete();
-
-
         String token = jwtProvider.generateToken(user.getEmail(),isProfileComplete);
         /*
         방법 1. 프론트와 연결 후 리다이렉트 방식으로 변경 프론트에서 토큰 추출 -> 프론트에서 replaceState()를 이용하여 URL에서 제거
-        response.sendRedirect("http://localhost:3000/oauth-success?token=" + token + "&isProfileComplete=" + isProfileComplete);
-        /*
-        * 방법 2. 프론트와 연결 후 리다이렉트 방식을 이용하지만 토큰을 Set-Cookie 헤더로 전달
-        * Cookie cookie = new Cookie("token", token);
-          cookie.setHttpOnly(true);
-          cookie.setPath("/");
-          cookie.setSecure(true); // HTTPS 환경일 때
-          response.addCookie(cookie);
-          response.sendRedirect("http://localhost:3000/oauth2/success");
-        * */
+        */
+        response.sendRedirect("http://localhost:3000/oauth-callback?token=" + token + "&isProfileComplete=" + isProfileComplete);
+
+        //방법 2. 프론트와 연결 후 리다이렉트 방식을 이용하지만 토큰을 Set-Cookie 헤더로 전달
+        /*Cookie cookie = new Cookie("token", token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setSecure(true); // HTTPS 환경일 때
+
+        Cookie profileCookie = new Cookie("isProfileComplete", isProfileComplete.toString());
+        profileCookie.setHttpOnly(false); // 프론트에서 읽어야 하므로 false
+        profileCookie.setPath("/");
+        profileCookie.setSecure(true); // HTTPS 환경에서는 true
+
+        response.addCookie(cookie);
+        response.addCookie(profileCookie);
+
+        response.sendRedirect("http://localhost:3000/oauth2/success");*/
+
 
         // json으로 응답 프론트에서 토큰을 꺼내어서 localStorage에 저장
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"token\": \"" + token + "\"}");
-        response.getWriter().flush();
+        /*response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"token\": \"" + token + "\", \"isProfileComplete\": " + isProfileComplete + "}");
+        response.getWriter().flush();*/
 
         log.info("✅ [구글 로그인] JWT 발급 완료 - 토큰 값: {}", token);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,8 @@ spring:
             client-id: ${CLIENT_ID}
             client-secret: ${CLIENT_SECRET}
             scope: openid, email, profile
-            redirect-uri: http://localhost:8090/login/oauth2/code/google
+            redirect-uri: ${REDIRECT_URI}
+            #redirect-uri: http://localhost:8090/login/oauth2/code/google
             authorization-grant-type: authorization_code
         provider:
           google:
@@ -25,7 +26,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: update # JPA를 통해 Entity에 작성한대로 테이블 자동 생성 -> 배포 시 변경
+      ddl-auto: create # JPA를 통해 Entity에 작성한대로 테이블 자동 생성 -> 배포 시 변경
     show-sql: true  # SQL 쿼리 로깅 활성화 -> 배포 시 변경
     properties:
       hibernate:


### PR DESCRIPTION
1. 백엔드 서버를 AWS EC2에 배포함에 따라 OAuth2 로그인 성공 후 리디렉트 URL을 React 프론트 콜백 페이지로 전달하도록 변경

2. 백엔드 GoogleOAuth2SuccessHandler에서 로그인 성공 후 토큰(JWT) 및 isProfileComplete 값을 쿼리 파라미터로 포함하여 /oauth-callback으로 리디렉트 처리

3. CORS 설정 수정: 로컬 React 개발 서버(`http://localhost:3000`) 요청 허용